### PR TITLE
[BUGFIX] - Partial-Data; Return correct partial data if requested

### DIFF
--- a/src/Service/Inertia.php
+++ b/src/Service/Inertia.php
@@ -35,7 +35,6 @@ class Inertia implements InertiaInterface
     {
         $this->page = $this->page
                         ->withComponent($component)
-                        ->withProps($props)
                         ->withUrl((string)$this->request->getUri());
 
         if ($this->request->hasHeader('X-Inertia-Partial-Data')) {

--- a/src/Service/Inertia.php
+++ b/src/Service/Inertia.php
@@ -38,8 +38,8 @@ class Inertia implements InertiaInterface
                         ->withUrl((string)$this->request->getUri());
 
         if ($this->request->hasHeader('X-Inertia-Partial-Data')) {
-            $only = $this->request->getHeader('X-Inertia-Partial-Data');
-            $props = ($only && $this->request->getHeaderLine('X-Inertia-Partial-Component'))
+            $only = explode(',', $this->request->getHeaderLine('X-Inertia-Partial-Data'));
+            $props = ($only && $this->request->getHeaderLine('X-Inertia-Partial-Component') === $component)
             ? array_intersect_key($props, array_flip((array) $only))
             : $props;
         }

--- a/test/Service/InertiaTest.php
+++ b/test/Service/InertiaTest.php
@@ -98,11 +98,9 @@ class InertiaTest extends TestCase
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->hasHeader('X-Inertia')->willReturn(true);
         $request->hasHeader('X-Inertia-Partial-Data')->willReturn(true);
-        $request->getHeaderLine('X-Inertia-Partial-Component')->willReturn(Argument::type('string'));
-        $request->getHeader('X-Inertia-Partial-Data')->willReturn([
-            'key2'
-        ]);
-        $json = '{"component":"type(string)","props":{"key2":"value2"},"url":"callback()","version":null}';
+        $request->getHeaderLine('X-Inertia-Partial-Component')->willReturn('component');
+        $request->getHeaderLine('X-Inertia-Partial-Data')->willReturn('key2');
+        $json = '{"component":"component","props":{"key2":"value2"},"url":"callback()","version":null}';
         $jsonResponse = null;
 
         $uri = $this->prophesize(UriInterface::class);
@@ -133,7 +131,7 @@ class InertiaTest extends TestCase
         );
 
         $returnedResponse = $inertia->render(
-            Argument::type('string'),
+            'component',
             [
                 'key1' => fn() => 'value1',
                 'key2' => fn() => 'value2'


### PR DESCRIPTION
### Problem
Request for Partial Data does not return correct response

### Analysis
In Interia->render() method ->withProps is called to early (and to often)

### Solution
Removed wrong ->withProps call and added Test to TestSuite
Fixed correct handling of partial request