### PR TITLE
Add LazyProps capability to Inertia class

### DIFF
--- a/src/Model/LazyProp.php
+++ b/src/Model/LazyProp.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cherif\InertiaPsr15\Model;
+
+/**
+ * NOTE: this is similar to Laravel Inertia\LazyProp
+ */
+final class LazyProp
+{
+    /**
+     * @var callable $callback
+     */
+    protected $callback;
+
+    public function __construct(
+        callable $callable
+    ) {
+        $this->callback = $callable;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function __invoke()
+    {
+        return call_user_func($this->callback);
+    }
+}


### PR DESCRIPTION
Hi @cherifGsoul !!
One more improvement if you think is good.   

In [Inertia documentation Partial Reloads](https://inertiajs.com/partial-reloads) we have this `Inertia::lazy` method that can determine which prop is only going to be returned when required it to.   

That's why I created this `LazyProp` class and updated the render method so we exclude this info when rendering the component.   

For me this is useful, because I have a page that I only want to render certain props, and then get other props on demand with Partial Data, so the page only adds this demanded props. (Hope this makes sense)

Let me know what you think about it.
Thank you very much!!!