### PR TITLE
Add ability for External Redirects

### DIFF
--- a/src/Middleware/InertiaMiddleware.php
+++ b/src/Middleware/InertiaMiddleware.php
@@ -103,6 +103,15 @@ class InertiaMiddleware implements MiddlewareInterface
             return $response->withStatus(303);
         }
 
+        // For External redirects
+        // https://inertiajs.com/redirects#external-redirects
+        if (
+            409 === $response->getStatusCode()
+            && $response->hasHeader('X-Inertia-Location')
+        ) {
+            return $response->withoutHeader('X-Inertia');
+        }
+
         return $response;
     }
 }

--- a/src/Service/Inertia.php
+++ b/src/Service/Inertia.php
@@ -95,4 +95,30 @@ class Inertia implements InertiaInterface
     {
         return new LazyProp($callable);
     }
+
+    /**
+     * @param string|ResponseInterface $destination
+     * @param int $status
+     * @return ResponseInterface
+     */
+    public function location($destination, int $status = 302): ResponseInterface
+    {
+        $response = $this->createResponse('', 'text/html; charset=UTF-8');
+
+        // We check if InertiaMiddleware has set up the 'X-Inertia-Location' header, so we handle the response accordingly
+        if ($this->request->hasHeader('X-Inertia')) {
+            $response = $response->withStatus(409);
+            return $response->withHeader(
+                'X-Inertia-Location',
+                $destination instanceof ResponseInterface ? $destination->getHeaderLine('Location') : $destination
+            );
+        }
+
+        if ($destination instanceof ResponseInterface) {
+            return $destination;
+        }
+
+        $response = $response->withStatus($status);
+        return $response->withHeader('Location', $destination);
+    }
 }

--- a/test/Service/InertiaTest.php
+++ b/test/Service/InertiaTest.php
@@ -292,4 +292,119 @@ class InertiaTest extends TestCase
         $this->assertSame($validJson, $jsonResponse);
     }
 
+    public function testLocationReturnResponseWithLocationAsStringWithNotExistingInertiaHeader()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $htmlResponse = null;
+
+        $response = $this->prophesize(ResponseInterface::class);
+        $responseFactory = $this->prophesize(ResponseFactoryInterface::class);
+        $responseFactory->createResponse()->willReturn($response);
+
+        $stream = $this->prophesize(StreamInterface::class);
+        $streamFactory = $this->prophesize(StreamFactoryInterface::class);
+        $streamFactory->createStream(Argument::type('string'))->will(function () use ($stream){
+            return $stream;
+        });
+
+        $rootViewProvider = $this->prophesize(RootViewProviderInterface::class);
+
+        $response->withBody($stream->reveal())->willReturn($response);
+        $response->withHeader('X-Inertia', true)->willReturn($response);
+        $response->withHeader('Content-Type', 'text/html; charset=UTF-8')->willReturn($response);
+        $response->withStatus(302)->willReturn($response);
+        $response->withHeader('Location', 'new-location')->willReturn($response);
+
+        $inertia = new Inertia(
+            $request->reveal(),
+            $responseFactory->reveal(),
+            $streamFactory->reveal(),
+            $rootViewProvider->reveal()
+        );
+
+
+        $returnedResponse = $inertia->location('new-location');
+
+        $this->assertInstanceOf(ResponseInterface::class, $returnedResponse);
+        $this->assertNotSame('', $htmlResponse);
+    }
+
+    public function testLocationReturnResponseWithLocationAsStringWithExistingInertiaHeader()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->hasHeader('X-Inertia')->willReturn(true);
+        $htmlResponse = null;
+
+        $response = $this->prophesize(ResponseInterface::class);
+        $responseFactory = $this->prophesize(ResponseFactoryInterface::class);
+        $responseFactory->createResponse()->willReturn($response);
+
+        $stream = $this->prophesize(StreamInterface::class);
+        $streamFactory = $this->prophesize(StreamFactoryInterface::class);
+        $streamFactory->createStream(Argument::type('string'))->will(function () use ($stream){
+            return $stream;
+        });
+
+        $rootViewProvider = $this->prophesize(RootViewProviderInterface::class);
+
+        $response->withBody($stream->reveal())->willReturn($response);
+        $response->withHeader('X-Inertia', true)->willReturn($response);
+        $response->withHeader('Content-Type', 'text/html; charset=UTF-8')->willReturn($response);
+        $response->withStatus(409)->willReturn($response);
+        $response->withHeader('X-Inertia-Location', 'new-location')->willReturn($response);
+
+        $inertia = new Inertia(
+            $request->reveal(),
+            $responseFactory->reveal(),
+            $streamFactory->reveal(),
+            $rootViewProvider->reveal()
+        );
+
+        $returnedResponse = $inertia->location('new-location');
+
+        $this->assertInstanceOf(ResponseInterface::class, $returnedResponse);
+        $this->assertNotSame('', $htmlResponse);
+    }
+
+    public function testLocationReturnResponseWithLocationAsResponseInterfaceWithExistingInertiaHeader()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->hasHeader('X-Inertia')->willReturn(true);
+        $htmlResponse = null;
+
+        $response = $this->prophesize(ResponseInterface::class);
+        $responseFactory = $this->prophesize(ResponseFactoryInterface::class);
+        $responseFactory->createResponse()->willReturn($response);
+
+        $stream = $this->prophesize(StreamInterface::class);
+        $streamFactory = $this->prophesize(StreamFactoryInterface::class);
+        $streamFactory->createStream(Argument::type('string'))->will(function () use ($stream){
+            return $stream;
+        });
+
+        $rootViewProvider = $this->prophesize(RootViewProviderInterface::class);
+
+        $response->withBody($stream->reveal())->willReturn($response);
+        $response->withHeader('X-Inertia', true)->willReturn($response);
+        $response->withHeader('Content-Type', 'text/html; charset=UTF-8')->willReturn($response);
+
+        $locationResponse = $this->prophesize(ResponseInterface::class);
+        $locationResponse->getHeaderLine('Location')->willReturn('new-location');
+
+        $response->withStatus(409)->willReturn($response);
+        $response->withHeader('X-Inertia-Location', $locationResponse instanceof ResponseInterface ? $locationResponse->getHeaderLine('Location') : $locationResponse)->willReturn($response);
+
+        $inertia = new Inertia(
+            $request->reveal(),
+            $responseFactory->reveal(),
+            $streamFactory->reveal(),
+            $rootViewProvider->reveal()
+        );
+
+        $returnedResponse = $inertia->location($locationResponse);
+
+        $this->assertInstanceOf(ResponseInterface::class, $returnedResponse);
+        $this->assertNotSame('', $htmlResponse);
+    }
+
 }


### PR DESCRIPTION
Hey @cherifGsoul!

Based on this part of the [documentation](https://inertiajs.com/redirects#external-redirects) and using the logic on [Laravel Inertia Library](https://github.com/inertiajs/inertia-laravel/tree/1.x), I'm creating this PR for your consideration.

If we send a 409 status code with the Header X-Inertia-Location (and without the Header X-Inertia), Inertia will make a redirect. This provide us the ability to do External Redirects, and also call internal routes that are not handled with the InertiaMiddleware.

I added some tests for your consideration as well.

Thank you very much for your time, your library and your prompt responses on this PRs, I appreciate it very much.

All the best!