### PR TITLE
Fix version check

### DIFF
--- a/src/Middleware/InertiaMiddleware.php
+++ b/src/Middleware/InertiaMiddleware.php
@@ -75,9 +75,13 @@ class InertiaMiddleware implements MiddlewareInterface
      */
     private function checkVersion($request, $response): Response
     {
+        if (empty($request->getHeader('X-Inertia-Version'))) {
+            return $response;
+        }
+
         if (
             'GET' === $request->getMethod()
-            && $request->getHeader('X-Inertia-Version') !== $this->inertia->getVersion()
+            && $request->getHeader('X-Inertia-Version')[0] !== $this->inertia->getVersion()
         ) {
             return $response->withAddedHeader('X-Inertia-Location', $request->getUri()->getPath());
         }

--- a/test/Middleware/InertiaMiddlewareTest.php
+++ b/test/Middleware/InertiaMiddlewareTest.php
@@ -50,7 +50,7 @@ class InertiaMiddlewareTest extends TestCase
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->withAttribute(InertiaMiddleware::INERTIA_ATTRIBUTE, Argument::that([$inertia, 'reveal']))->willReturn($request);
         $request->hasHeader('X-Inertia')->willReturn(true);
-        $request->getHeader('X-Inertia-Version')->willReturn('12345');
+        $request->getHeader('X-Inertia-Version')->willReturn(['12345']);
         $request->getMethod()->willReturn('GET');
         
         $factory->fromRequest($request)->willReturn($inertia);
@@ -82,7 +82,7 @@ class InertiaMiddlewareTest extends TestCase
         $request->getUri()->willReturn($uri);
         $request->withAttribute(InertiaMiddleware::INERTIA_ATTRIBUTE, $inertia->reveal())->willReturn($request);
         $request->hasHeader('X-Inertia')->willReturn(true);
-        $request->getHeader('X-Inertia-Version')->willReturn('12345');
+        $request->getHeader('X-Inertia-Version')->willReturn(['12345']);
         $request->getMethod()->willReturn('GET');
         
         $factory->fromRequest($request)->willReturn($inertia);
@@ -111,7 +111,7 @@ class InertiaMiddlewareTest extends TestCase
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->withAttribute(InertiaMiddleware::INERTIA_ATTRIBUTE, $inertia->reveal())->willReturn($request);
         $request->hasHeader('X-Inertia')->willReturn(true);
-        $request->getHeader('X-Inertia-Version')->willReturn('12345');
+        $request->getHeader('X-Inertia-Version')->willReturn(['12345']);
         $request->getMethod()->willReturn('PUT');
         
         $factory->fromRequest($request)->willReturn($inertia);
@@ -141,7 +141,7 @@ class InertiaMiddlewareTest extends TestCase
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->withAttribute(InertiaMiddleware::INERTIA_ATTRIBUTE, $inertia->reveal())->willReturn($request);
         $request->hasHeader('X-Inertia')->willReturn(true);
-        $request->getHeader('X-Inertia-Version')->willReturn('12345');
+        $request->getHeader('X-Inertia-Version')->willReturn(['12345']);
         $request->getMethod()->willReturn('POST');
 
         $factory->fromRequest($request)->willReturn($inertia);


### PR DESCRIPTION
Hi @cherifGsoul,
Please consider this PR to fix a problem that I've found with the version.
https://www.php-fig.org/psr/psr-7/ states that `getHeader` from a request returns an array, so this PR changes `checkVersion` to handle this data as an array.

Let me know what you think.
Thanks!